### PR TITLE
Helia Package export error solved

### DIFF
--- a/dist/cjs/services/helia-client.js
+++ b/dist/cjs/services/helia-client.js
@@ -1,4 +1,4 @@
-"use strict";
+    "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -13,9 +13,9 @@ exports.HeliaStorageService = void 0;
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 const base_storage_js_1 = require("./base-storage.js");
-const helia_1 = require("helia");
-const json_1 = require("@helia/json");
-const unixfs_1 = require("@helia/unixfs");
+const helia_1 = import("helia");
+const json_1 = import("@helia/json");
+const unixfs_1 = import("@helia/unixfs");
 const fs_1 = require("fs");
 class HeliaStorageService extends base_storage_js_1.StorageService {
     constructor(config) {


### PR DESCRIPTION
If you see errors similar to Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in node_modules/ipfs/package.json you are likely trying to load ESM code from a CJS environment via require. This is not possible, instead it must be loaded using import.

The above issue is solved by changing the imports in ```helia-client.js``` file as mentioned in the issue [here ](https://github.com/ipfs/js-ipfs/blob/master/docs/upgrading/v0.62-v0.63.md#esm)